### PR TITLE
io File objects in VAPID constructor

### DIFF
--- a/tests/test_vapid.py
+++ b/tests/test_vapid.py
@@ -1,3 +1,4 @@
+import io
 import os
 import unittest
 from pathlib import Path
@@ -43,3 +44,31 @@ class ValidateVAPID(unittest.TestCase):
         public_fd.close()
 
         self.assertIsNotNone(header)
+
+    def test_BytesIO_keys_get_authorization_header(self):
+        private_key, public_key, _ = VAPID.generate_keys()
+
+        public_fd = io.BytesIO()
+        public_fd.write(public_key)
+        public_fd.seek(0)
+
+        private_fd = io.BytesIO()
+        private_fd.write(private_key)
+        private_fd.seek(0)
+
+        vapid = VAPID(private_key=private_fd, public_key=public_fd)
+
+        header = vapid.get_authorization_header(
+            endpoint=AnyHttpUrl("http://google.com"),
+            subscriber="test@mail.com",
+            expiration=10,
+        )
+
+        private_fd.close()
+        public_fd.close()
+
+        self.assertIsNotNone(header)
+
+
+
+

--- a/webpush/vapid.py
+++ b/webpush/vapid.py
@@ -1,6 +1,7 @@
 import time
 from base64 import urlsafe_b64encode
 from pathlib import Path
+import io
 
 import jwt
 from cryptography.hazmat.backends import default_backend
@@ -25,27 +26,35 @@ class VAPID:
     VAPID (Voluntary Application Server Identification)
     """
 
-    def __init__(self, private_key: str | Path, public_key: str | Path) -> None:
-        if isinstance(private_key, str):
-            private_key = Path(private_key)
-        if isinstance(public_key, str):
-            public_key = Path(public_key)
+    def __init__(self, private_key: str | Path | io.StringIO | io.BytesIO, public_key: str | Path | io.BytesIO) -> None:
 
-        if not private_key.expanduser().exists():
-            raise VAPIDException("Private key file doesn't exists")
 
-        if not public_key.expanduser().exists():
-            raise VAPIDException("Public key file doesn't exists")
+        # Load the private key
+        if isinstance(private_key, io.BytesIO) or isinstance(private_key, io.StringIO):
+            self.private_key = private_key.read()
+        else:
+            private_key_path = Path(private_key)
 
-        with open(private_key) as fd:
-            self.private_key = fd.read()
+            if not private_key_path.expanduser().exists():
+                raise VAPIDException("Private key file doesn't exists")
 
-        with open(public_key, "rb") as fd:
-            self.public_key = serialization.load_pem_public_key(fd.read())
+            with open(private_key_path) as fd:
+                self.private_key = fd.read()
 
-    def get_authorization_header(
-        self, endpoint: AnyHttpUrl, subscriber: EmailStr, expiration: int
-    ) -> str:
+        # Load the public key
+        if isinstance(private_key, io.BytesIO):
+            public_key_bytes = public_key.read()
+            self.public_key = serialization.load_pem_public_key(public_key_bytes)
+        else:
+            public_key_path = Path(public_key)
+
+            if not public_key_path.expanduser().exists():
+                raise VAPIDException("Public key file doesn't exists")
+
+            with open(public_key_path, "rb") as fd:
+                self.public_key = serialization.load_pem_public_key(fd.read())
+
+    def get_authorization_header(self, endpoint: AnyHttpUrl, subscriber: EmailStr, expiration: int) -> str:
         """
         :param endpoint from subscribtion info
         :param subscriber email for response in vapid


### PR DESCRIPTION
I want to use your library in an environment where there actually is no file system. This means that I can not pass in a path string nor a temp file path like you do in the `test_get_authorization_header` test. It would be very nice if I could pass in my own file objects from `io.BytesIO` and `io.StringIO` into the VAPID constructor from [vapid.py](./webpush/vapid.py). This pull request adds this possibility. 

It is a backwards compatible change. You can still pass in a string file path and that still just works. I use `isinstance` for this. 

I also added a test for this change: `test_BytesIO_keys_get_authorization_header`. The other test you already had still pass after my changes. 
 